### PR TITLE
Mixing int32 and int64 types in comparisons leads to errors (certainl…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: test test-separate verify_32 verify_64
+all: test test-separate test-sqrt verify_32 verify_64
 	true
 
 test: test.c fixedptc.h
@@ -13,3 +13,6 @@ verify_64: verify.c fixedptc.h
 test-separate: test-separate.c test-separate-impl.c fixedptc.h
 	gcc -o test-separate -O3 -Wall $(CFLAGS) $(LDFLAGS) \
 		test-separate.c test-separate-impl.c
+
+test-sqrt: test-sqrt.c fixedptc.h
+	gcc -o test-sqrt -O3 -Wall $(CFLAGS) $(LDFLAGS) -lm test-sqrt.c

--- a/fixedptc.h
+++ b/fixedptc.h
@@ -173,7 +173,7 @@ typedef	__uint128_t fixedptud;
 #define fixedpt_xmul(A,B)						\
 	((fixedpt)(((fixedptd)(A) * (fixedptd)(B)) >> FIXEDPT_FBITS))
 #define fixedpt_xdiv(A,B)						\
-	((fixedpt)(((fixedptd)(A) << FIXEDPT_FBITS) / (fixedptd)(B)))
+	((fixedptd)(((fixedptd)(A) << FIXEDPT_FBITS) / (fixedptd)(B)))
 #define fixedpt_fracpart(A) ((fixedpt)(A) & FIXEDPT_FMASK)
 
 #define FIXEDPT_ONE	((fixedpt)((fixedpt)1 << FIXEDPT_FBITS))
@@ -317,12 +317,12 @@ FIXEDPTC__EXPORT_SYMBOL(fixedpt_cstr);
 
 /* Returns the square root of the given number, or -1 in case of error */
 FIXEDPTC__PROTO fixedpt
-fixedpt_sqrt(fixedpt A)
+fixedpt_sqrt(fixedptd A)
 {
 	int invert = 0;
 	int iter = FIXEDPT_FBITS;
 	int i;
-	fixedpt l;
+	fixedptd l;
 
 	if (A < 0)
 		return (-1);
@@ -330,10 +330,10 @@ fixedpt_sqrt(fixedpt A)
 		return (A);
 	if (A < FIXEDPT_ONE && A > 6) {
 		invert = 1;
-		A = fixedpt_div(FIXEDPT_ONE, A);
+		A = fixedpt_xdiv(FIXEDPT_ONE, A);
 	}
 	if (A > FIXEDPT_ONE) {
-		fixedpt s = A;
+		fixedptd s = A;
 
 		iter = 0;
 		while (s > 0) {
@@ -345,9 +345,9 @@ fixedpt_sqrt(fixedpt A)
 	/* Newton's iterations */
 	l = (A >> 1) + 1;
 	for (i = 0; i < iter; i++)
-		l = (l + fixedpt_div(A, l)) >> 1;
+		l = (l + fixedpt_xdiv(A, l)) >> 1;
 	if (invert)
-		return (fixedpt_div(FIXEDPT_ONE, l));
+		return (fixedpt_xdiv(FIXEDPT_ONE, l));
 	return (l);
 }
 FIXEDPTC__EXPORT_SYMBOL(fixedpt_sqrt);

--- a/fixedptc.h
+++ b/fixedptc.h
@@ -227,6 +227,8 @@ FIXEDPTC__EXPORT_SYMBOL(fixedpt_mul);
 FIXEDPTC__PROTO fixedpt
 fixedpt_div(fixedpt A, fixedpt B)
 {
+	if (B == 0)
+		return 0;
 	return (((fixedptd)A << FIXEDPT_FBITS) / (fixedptd)B);
 }
 FIXEDPTC__EXPORT_SYMBOL(fixedpt_div);

--- a/fixedptc.h
+++ b/fixedptc.h
@@ -319,7 +319,8 @@ fixedpt_sqrt(fixedpt A)
 {
 	int invert = 0;
 	int iter = FIXEDPT_FBITS;
-	int l, i;
+	int i;
+	fixedpt l;
 
 	if (A < 0)
 		return (-1);
@@ -330,7 +331,7 @@ fixedpt_sqrt(fixedpt A)
 		A = fixedpt_div(FIXEDPT_ONE, A);
 	}
 	if (A > FIXEDPT_ONE) {
-		int s = A;
+		fixedpt s = A;
 
 		iter = 0;
 		while (s > 0) {

--- a/test-sqrt.c
+++ b/test-sqrt.c
@@ -1,0 +1,24 @@
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <math.h>
+
+/* Test for square root function for 64 bits */
+
+#define FIXEDPT_BITS 64
+#define FIXEDPT_WBITS 14
+
+#include "fixedptc.h"
+
+int main() {
+
+	fixedpt A = fixedpt_rconst(0.154632);
+
+	printf("fixedptc library version: %s\n", FIXEDPT_VCSID);
+	printf("Using %d-bit precision, %d.%d format\n\n", FIXEDPT_BITS, FIXEDPT_WBITS, FIXEDPT_FBITS);
+
+	printf("sqrt(%lf)= %lf\n", fixedpt_tofloat(A), sqrt(fixedpt_tofloat(A)));
+	printf("fixedpt_sqrt(%f) = %s\n", fixedpt_tofloat(A), fixedpt_cstr(fixedpt_sqrt(A), -1));
+
+	return (0);
+}


### PR DESCRIPTION
…y on x86_64 builds)

Built a small test routine calling fixedpt_sqrt(x) where 0>x<1 with -DFIXEDPT_BITS=64 -DFIXEDPT_WBITS=14
Returned a pathological and incorrect result:
     fixedpt_sqrt(0.070700)) = 7314.706333859 (expected 0.265895)

 Comparison & conversions of int32 & int64 values to blame .
